### PR TITLE
When Rails version is 6.0.0, skip this.

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -50,7 +50,11 @@ module ActsAsTaggableOn::Taggable
               parsed_new_list = ActsAsTaggableOn.default_parser.new(new_tags).parse
 
               if self.class.preserve_tag_order? || parsed_new_list.sort != #{tag_type}_list.sort
-                set_attribute_was('#{tag_type}_list', #{tag_type}_list)
+                if Rails.version.to_f < 6.0
+                  set_attribute_was('#{tag_type}_list', #{tag_type}_list)
+                else
+                  d_mutations_from_database.change_to_attribute('#{tag_type}_list')
+                end
                 write_attribute("#{tag_type}_list", parsed_new_list)
               end
 


### PR DESCRIPTION
To fix https://github.com/mbleigh/acts-as-taggable-on/issues/955
When the Rails version is 6.0.0, it becomes true, so I want to skip set_attribute_was.