### PR TITLE
Update tag.rb

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -123,7 +123,7 @@ module ActsAsTaggableOn
 
       def unicode_downcase(string)
         if ActiveSupport::Multibyte::Unicode.respond_to?(:downcase)
-          ActiveSupport::Multibyte::Unicode.downcase(string)
+          string.downcase
         else
           ActiveSupport::Multibyte::Chars.new(string).downcase.to_s
         end


### PR DESCRIPTION
```rb
DEPRECATION WARNING: ActiveSupport::Multibyte::Unicode#downcase is deprecated and will be removed from Rails 6.1. Use String methods directly. (called from unicode_downcase at /vendor/bundle/ruby/2.6.0/bundler/gems/acts-as-taggable-on-d01c315f616b/lib/acts_as_taggable_on/tag.rb:126)
```

ref https://github.com/rails/rails/commit/619b2ae6a489c627096a36aa63fdff546ce766d1